### PR TITLE
Remove duplicate `background_alpha` MangoHud config option

### DIFF
--- a/templates/benchmark_create.tmpl
+++ b/templates/benchmark_create.tmpl
@@ -58,7 +58,6 @@
                 <pre><code class="language-ini">
 legacy_layout=false
 
-background_alpha=0.6
 round_corners=0
 background_alpha=0.6
 background_color=000000


### PR DESCRIPTION
There's a duplicate MangoHud config line, `background_alpha=0.6` appears on both lines 61 and 64 and this PR removes the first.