### PR TITLE
fix relative % avg not always based on the lowest scoring baseline

### DIFF
--- a/static/js/benchmark.js
+++ b/static/js/benchmark.js
@@ -143,18 +143,14 @@ Highcharts.chart('fpsMinMaxAvgChart', {
 // Calculate average FPS for each filename
 const avgFPSData2 = fpsDataArrays.map(dataArray => calculateAverage(dataArray.data));
 
-// Calculate FPS as a percentage of the first element
-const firstFPS = avgFPSData2[0];
-const percentageFPSData = avgFPSData2.map(fps => (fps / firstFPS) * 100);
-
-// Ensure the minimum FPS percentage is 100%
-const minPercentage = Math.min(...percentageFPSData);
-const normalizedPercentageFPSData = percentageFPSData.map(percentage => percentage - minPercentage + 100);
+// Calculate FPS as a percentage of the lowest baseline
+const baselineFPS = Math.min(...avgFPSData2);
+const percentageFPSData = avgFPSData2.map((fps) => (fps / baselineFPS) * 100);
 
 // Create an array of objects to sort both categories and data together
 const sortedData = fpsDataArrays.map((dataArray, index) => ({
     label: dataArray.label,
-    percentage: normalizedPercentageFPSData[index]
+    percentage: percentageFPSData[index]
 }));
 
 // Sort the array by percentage
@@ -294,18 +290,16 @@ Highcharts.chart('frametimeMinMaxAvgChart', {
 // Calculate average Frametime for each filename
 const avgFrametimeData2 = frameTimeDataArrays.map(dataArray => calculateAverage(dataArray.data));
 
-// Calculate Frametime as a percentage of the first element
-const firstFrametime = avgFrametimeData2[0];
-const percentageFrametimeData = avgFrametimeData2.map(frametime => (frametime / firstFrametime) * 100);
-
-// Ensure the minimum Frametime percentage is 100%
-const minFrametimePercentage = Math.min(...percentageFrametimeData);
-const normalizedPercentageFrametimeData = percentageFrametimeData.map(percentage => percentage - minFrametimePercentage + 100);
+// Calculate Frametime as a percentage of the lowest baseline
+const baselineFrametime = Math.min(...avgFrametimeData2);
+const percentageFrametimeData = avgFrametimeData2.map(
+    (frametime) => (frametime / baselineFrametime) * 100
+);
 
 // Create an array of objects to sort both categories and data together
 const sortedFrametimeData = frameTimeDataArrays.map((dataArray, index) => ({
     label: dataArray.label,
-    percentage: normalizedPercentageFrametimeData[index]
+    percentage: percentageFrametimeData[index]
 }));
 
 // Sort the array by percentage


### PR DESCRIPTION
the baseline to calculate the % improvement was just whichever file was the first in the avgFPS/Frametime data arrays resulting in incorrect % improvement comparisons being made. 
the PR fixes this by simply comparing to the minimum baseline instead of just the 0th index of those arrays which just makes it dependent on the order they are in that array, not which result is actually the minimum 100% baseline. this also eliminates the need for that extra step after to "ensure the minimum is 100%" as that's exactly what this does.

## example

before:

<img width="1689" height="315" alt="image" src="https://github.com/user-attachments/assets/0d97a055-57c3-49d6-8e75-87272c6c3a87" />

after:

<img width="1693" height="307" alt="image" src="https://github.com/user-attachments/assets/55e0cace-2be4-4d58-9dac-707a95c1d293" />

in the example the baseline FPS was `433.27` and the best was `693.31` which makes it `693.31/433.27=1.60018002631` better, as correctly shown after this fix but incorrectly shown as a 155.11% improvement before. the 155.11 comes from it comparing to just whichever file was 0th in that array which was not guaranteed to actually be the 100% baseline it should be making comparisons to.