### PR TITLE
Fix version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: VERSION=${{ github.event.release.tag_name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,9 +47,9 @@ RUN mkdir -p internal/app/web && \
         echo '}'; \
     } > internal/app/webfs_embed.go
 
-# Build the application with version from git
-RUN VERSION=$(git describe --tags --always 2>/dev/null || echo "dev") && \
-    CGO_ENABLED=1 GOOS=linux go build -ldflags="-w -s -X main.version=${VERSION}" -trimpath -tags netgo -o server ./cmd/server
+# Build the application with version
+ARG VERSION=dev
+RUN CGO_ENABLED=1 GOOS=linux go build -ldflags="-w -s -X main.version=${VERSION}" -trimpath -tags netgo -o server ./cmd/server
 
 # Runtime stage
 FROM alpine:3.23


### PR DESCRIPTION
This pull request updates the way the application version is injected into the build process, ensuring that the version specified in the GitHub release is used consistently in both the Docker build and the application binary. The main changes are focused on improving version management during builds.

Build and versioning improvements:

* The Docker build process now accepts a `VERSION` build argument, which is used to set the application version in the binary, replacing the previous approach that relied on `git describe` inside the Dockerfile. (`Dockerfile`)
* The GitHub Actions release workflow passes the release tag name as the `VERSION` build argument to the Docker build, ensuring the built image is correctly versioned according to the release. (`.github/workflows/release.yml`)